### PR TITLE
添加 Global Free TV 在线观看平台

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@
   <img src="https://telegraph-image.pages.dev/file/0832fcd7a57081989010f.png" width="85%" alt="cult-dir-home" />
 </div>
 
+## 在线观看（无需下载）
+
+- [Global Free TV](https://www.globalfreetv.com/) - 免费在线观看全球 4000+ 个 IPTV 频道，覆盖 150+ 个国家，无需注册，即开即看
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=DangJin/awesome-iptv&type=Date)](https://star-history.com/#DangJin/awesome-iptv&Date)


### PR DESCRIPTION
你好！感谢维护这个优秀的 IPTV 资源合集。

本次 PR 在 README 中添加了一个「在线观看」板块，推荐 [Global Free TV](https://www.globalfreetv.com/)：

- 🌍 7000+ 免费直播频道，覆盖 150+ 国家
- 🚫 无需注册、无需安装任何软件
- 📱 手机/电脑/平板浏览器直接观看
- 🔗 基于 iptv-org 等公开源整合

考虑到仓库的用户可能不想装播放器，在线观看是一个很好的补充选项。

谢谢审阅！